### PR TITLE
support tiktoken

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,39 @@
+[cl100k_base]
+git-tree-sha1 = "a2c91b0a5daf9ea7bb2cdf77ab9fa15d4359a6cd"
+lazy = true
+
+    [[cl100k_base.download]]
+    sha256 = "740f8d96af2dbe385ad9b4134771fc4c960d699dea2346ce60fb6174e064fcc1"
+    url = "https://gist.github.com/chengchingwen/5b5d72f9f0863008bb50f457f506f1f7/raw/a2c91b0a5daf9ea7bb2cdf77ab9fa15d4359a6cd.tar.gz"
+
+[gpt2]
+git-tree-sha1 = "de3ac756f1ed860391cd123771f154d3c58fa0fc"
+lazy = true
+
+    [[gpt2.download]]
+    sha256 = "7f03d8a9999a3c69e84f0f031ba511b9e785edce39e1a854e7c864437c96a816"
+    url = "https://gist.github.com/chengchingwen/6ceded526bc1fecd55474cf8364c94fd/raw/de3ac756f1ed860391cd123771f154d3c58fa0fc.tar.gz"
+
+[p50k_base]
+git-tree-sha1 = "514eaf67879c714ae1bf33e8949ab59932d3b7fc"
+lazy = true
+
+    [[p50k_base.download]]
+    sha256 = "6f6259e8905facbc067c3f97ece9a05748a7be0168d633b3d43bbb09a0e981f9"
+    url = "https://gist.github.com/chengchingwen/c4a15090139457390c00278d38e29318/raw/514eaf67879c714ae1bf33e8949ab59932d3b7fc.tar.gz"
+
+[p50k_edit]
+git-tree-sha1 = "636cc6241565724b6ca50221f07c432ba9e9a451"
+lazy = true
+
+    [[p50k_edit.download]]
+    sha256 = "4a1b83a50b17e096b385159489ffcd1f1f7a2d54eb8be00b1b67616f811c10e1"
+    url = "https://gist.github.com/chengchingwen/5fe7aec1fffd346467f92a59d65c411c/raw/636cc6241565724b6ca50221f07c432ba9e9a451.tar.gz"
+
+[r50k_base]
+git-tree-sha1 = "d489e06f7a919292cc62d320c2a4fb4dc33ad260"
+lazy = true
+
+    [[r50k_base.download]]
+    sha256 = "17eed7f24af763ae4d8ea063486ef06de69acacaffabacc5493fbaf1c42b71f2"
+    url = "https://gist.github.com/chengchingwen/a20828bf3c92cf891b0bd785430cba18/raw/d489e06f7a919292cc62d320c2a4fb4dc33ad260.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,11 @@ authors = ["chengchingwen <adgjl5645@hotmail.com>"]
 version = "0.4.0"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DoubleArrayTries = "abbaa0e5-f788-499c-92af-c35ff4258c82"
+LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 StructWalk = "31cdf514-beb7-4750-89db-dda9d2eb8d3d"
 TextEncodeBase = "f92c20c0-9f2a-4705-8116-881385faba05"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -19,11 +19,3 @@ DoubleArrayTries = "0.1"
 StructWalk = "0.2"
 TextEncodeBase = "0.5.4, 0.6, 0.7"
 julia = "1.6"
-
-[extras]
-DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test", "DelimitedFiles", "Downloads"]

--- a/src/BytePairEncoding.jl
+++ b/src/BytePairEncoding.jl
@@ -12,5 +12,6 @@ include("bytefallback.jl")
 include("tokenization.jl")
 include("learn.jl")
 include("gpt2_utils.jl")
+include("tiktoken.jl")
 
 end # module

--- a/src/bpe.jl
+++ b/src/bpe.jl
@@ -44,8 +44,11 @@ end
 
 Base.show(io::IO, bpe::CachedBPE) = (print(io, "CachedBPE("); show(io, bpe.bpe); print(io, ')'))
 
+getrank(ranks, m) = get(ranks, m, typemax(eltype(values(ranks))))
+getrank(bpe::AbstractBPE, m) = getrank(bpe.merging_rank, m)
 
-function lowestrank(merging_rank, ms::MutableLinkedList)
+lowestrank(bpe_or_ranks, ms::MutableLinkedList) = lowestrank(ms)
+function lowestrank(ms::MutableLinkedList)
     # `MutableLinkedList` use the meta node to record the first & last node
     # Meanwhile, both prev(first node) and next(last node) point to the meta node
     metanode = ms.node
@@ -67,17 +70,17 @@ function lowestrank(merging_rank, ms::MutableLinkedList)
     return lst, li
 end
 
-function merge_loop!(merging_rank, ms, x)
+function merge_loop!(bpe_or_ranks, ms, x)
     for _ in 1:length(ms)
-        r, i = lowestrank(merging_rank, ms)
+        r, i = lowestrank(bpe_or_ranks, ms)
         r == typemax(Int) && break
-        merge!(ms, i, merging_rank)
+        merge!(ms, i, bpe_or_ranks)
         isone(length(ms)) && break
     end
     return
 end
 
-function _merge!(node, m1, metanode, ms, ranks)
+function _merge!(node, m1, metanode, ms, bpe_or_ranks)
     nextnode = node.next
     newnextnode = nextnode.next
     m2 = first(nextnode.data)
@@ -86,7 +89,7 @@ function _merge!(node, m1, metanode, ms, ranks)
         r = typemax(Int)
     else
         m3 = first(newnextnode.data)
-        r = get(ranks, (m, m3), typemax(Int))
+        r = getrank(bpe_or_ranks, (m, m3))
     end
     node.data = (m, r)
     node.next = newnextnode
@@ -95,20 +98,20 @@ function _merge!(node, m1, metanode, ms, ranks)
     prevnode = node.prev
     if prevnode !== metanode
         m0 = first(prevnode.data)
-        r = get(ranks, (m0, m), typemax(Int))
+        r = getrank(bpe_or_ranks, (m0, m))
         prevnode.data = (m0, r)
     end
     return newnextnode
 end
 
-function merge!(ms::MutableLinkedList, node, ranks)
+function merge!(ms::MutableLinkedList, node, bpe_or_ranks)
     metanode = ms.node
     m1, r = node.data
-    node = _merge!(node, m1, metanode, ms, ranks)
+    node = _merge!(node, m1, metanode, ms, bpe_or_ranks)
     while node !== metanode
         m1, r1 = node.data
         if r1 == r
-            node = _merge!(node, m1, metanode, ms, ranks)
+            node = _merge!(node, m1, metanode, ms, bpe_or_ranks)
         else
             node = node.next
         end
@@ -124,7 +127,6 @@ units2merge(unit::Merge) = unit
 
 function merges(bpe::AbstractBPE, x::AbstractString, itr = units_itr(bpe, x))
     endsym = bpe.endsym
-    ranks = bpe.merging_rank
     l = MutableLinkedList{Tuple{Merge, Int}}()
 
     v_state = iterate(itr)
@@ -139,7 +141,7 @@ function merges(bpe::AbstractBPE, x::AbstractString, itr = units_itr(bpe, x))
                 m1 = Merge(m1, true)
                 if !isempty(l)
                     m0 = first(pop!(l))
-                    r0 = get(ranks, (m0, m1), typemax(Int))
+                    r0 = getrank(bpe, (m0, m1))
                     push!(l, (m0, r0))
                 end
             end
@@ -148,13 +150,15 @@ function merges(bpe::AbstractBPE, x::AbstractString, itr = units_itr(bpe, x))
         else
             gh2, state = v_state
             m2 = units2merge(gh2)
-            r = get(ranks, (m1, m2), typemax(Int))
+            r = getrank(bpe, (m1, m2))
             push!(l, (m1, r))
             m1 = m2
         end
     end
     return l
 end
+
+as_string(bpe::AbstractBPE, m::Merge) = as_string(m, bpe.sepsym, bpe.endsym)
 
 function _merges2string!(bpe, ms)
     len = length(ms)
@@ -166,7 +170,7 @@ function _merges2string!(bpe, ms)
     while true
         node === metanode && break
         m, _ = node.data
-        @inbounds y[i] = as_string(m, bpe.sepsym, bpe.endsym)
+        @inbounds y[i] = as_string(bpe, m)
         prevnode = node
         node = node.next
         i += 1
@@ -184,7 +188,7 @@ function bytepairencode(bpe::AbstractBPE, x::AbstractString)
         m, r = pop!(ms)
         push!(ms, (Merge(m, !isnothing(bpe.endsym)), r))
     else
-        merge_loop!(bpe.merging_rank, ms, x)
+        merge_loop!(bpe, ms, x)
     end
     y = _merges2string!(bpe, ms)
     return y

--- a/src/bytefallback.jl
+++ b/src/bytefallback.jl
@@ -38,7 +38,6 @@ function Base.iterate(itr::ByteUnitsIterator)
     return iterate(itr, (offset, 1, 1))
 end
 function Base.iterate(itr::ByteUnitsIterator, state)
-    # Main.@bp
     str = itr.string
     len = str.ncodeunits
     offset, nu, bid = state

--- a/src/gpt2_utils.jl
+++ b/src/gpt2_utils.jl
@@ -1,3 +1,6 @@
+using Artifacts
+using TextEncodeBase
+
 # function bytes_to_unicode()
 #   cs = vcat(collect(('!'):('~')), collect(('¡'):('¬')), collect(('®'):('ÿ')))
 #   bs = map(Int, cs)
@@ -21,4 +24,22 @@ gpt2_codemap() = CodeMap(Pair[0:32=>256:288, 127:160=>289:322, 173=>323])
 function gpt2_tokenizer(text)
   pattern = r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"
   return map(x->String(x.match), eachmatch(pattern, text))
+end
+
+function load_gpt2()
+    ENDOFTEXT = "<|endoftext|>"
+    artifact_dir = artifact"gpt2"
+    path = joinpath(artifact_dir, "vocab.bpe")
+    bpe = BPE(path)
+    base_tkr = GPT2Tokenization()
+    matches = [ENDOFTEXT]
+    tkr = TextEncodeBase.FlatTokenizer(
+        TextEncodeBase.MatchTokenization(
+            TextEncodeBase.CodeNormalizer(
+                BPETokenization(base_tkr, bpe),
+                gpt2_codemap()),
+            matches
+        )
+    )
+    return tkr
 end

--- a/src/gpt2_utils.jl
+++ b/src/gpt2_utils.jl
@@ -26,11 +26,16 @@ function gpt2_tokenizer(text)
   return map(x->String(x.match), eachmatch(pattern, text))
 end
 
+load_gpt2_bpe() = BPE(joinpath(artifact"gpt2", "vocab.bpe"))
+
+"""
+    load_gpt2()
+
+Load gpt2 tokenizer.
+"""
 function load_gpt2()
     ENDOFTEXT = "<|endoftext|>"
-    artifact_dir = artifact"gpt2"
-    path = joinpath(artifact_dir, "vocab.bpe")
-    bpe = BPE(path)
+    bpe = load_gpt2_bpe()
     base_tkr = GPT2Tokenization()
     matches = [ENDOFTEXT]
     tkr = TextEncodeBase.FlatTokenizer(

--- a/src/gpt2_utils.jl
+++ b/src/gpt2_utils.jl
@@ -1,4 +1,4 @@
-using Artifacts
+using Artifacts, LazyArtifacts
 using TextEncodeBase
 
 # function bytes_to_unicode()

--- a/src/tiktoken.jl
+++ b/src/tiktoken.jl
@@ -1,6 +1,7 @@
 using Artifacts, LazyArtifacts
 using Base64
 using TextEncodeBase
+using DoubleArrayTries: StringView
 
 _load_tiktoken_encoder_dict(path) = Dict((((token, rank) = split(line); base64decode(token) => parse(Int, rank)) for line in readlines(path)))
 _load_tiktoken_encoder(path) = TikTokenBPE(_load_tiktoken_encoder_dict(path))
@@ -20,13 +21,22 @@ function cl100k_base_tokenizer(text)
     return map(x->String(x.match), eachmatch(pattern, text))
 end
 
+"""
+    load_tiktoken(name)
+
+Load tiktoken tokenizer. `name` can be `"cl100k_base"`, `"p50k_base"`, `"p50k_base"`, `"r50k_base"`, or `"gpt2"`.
+"""
 function load_tiktoken(name)
     ENDOFTEXT = "<|endoftext|>"
     FIM_PREFIX = "<|fim_prefix|>"
     FIM_MIDDLE = "<|fim_middle|>"
     FIM_SUFFIX = "<|fim_suffix|>"
     ENDOFPROMPT = "<|endofprompt|>"
-    bpe = load_tiktoken_bpe(name)
+    if name == "gpt2"
+        bpe = bbpe2tiktoken(load_gpt2_bpe(), gpt2_codemap())
+    else
+        bpe = load_tiktoken_bpe(name)
+    end
     if name == "cl100k_base"
         base_tkr = Cl100kBaseTokenization()
         matches = [ENDOFTEXT, FIM_PREFIX, FIM_MIDDLE, FIM_SUFFIX, ENDOFPROMPT]
@@ -71,3 +81,90 @@ function getrank(bpe::TikTokenBPE, m)
     r = get(bpe.encoder, @inbounds(@view(codeunits(m.string)[m.offset .+ (1:m.ncodeunits)])), typemax(Int))
     return r
 end
+
+# converter
+struct TikToken2BBPE <: AbstractBPE
+    bpe::TikTokenBPE
+    max_rank::Base.RefValue{Int}
+end
+(bpe::TikToken2BBPE)(x) = bytepairencode(bpe, x)
+units_itr(bpe::TikToken2BBPE, x) = units_itr(bpe.bpe, x)
+function getrank(bpe::TikToken2BBPE, m)
+    r = getrank(bpe.bpe, m)
+    return r >= bpe.max_rank[] ? typemax(Int) : r
+end
+Base.getproperty(bpe::TikToken2BBPE, sym::Symbol) = sym == :endsym || sym == :sepsym ? nothing : getfield(bpe, sym)
+
+function tiktoken2bbpe(tkr, codemap::Union{CodeMap, Nothing} = nothing)
+    found = Ref(false)
+    return replace(tkr) do x
+        x isa BPETokenization && found[] && !isnothing(codemap) && return CodeNormalizer(x, codemap)
+        x isa TikTokenBPE && (found[] = true) && return tiktoken2bbpe(x, codemap)
+        return x
+    end
+end
+function tiktoken2bbpe(_bpe::TikTokenBPE, codemap::Union{CodeMap, Nothing} = nothing)
+    encoder = _bpe.encoder
+    bpe = TikToken2BBPE(_bpe, Ref(0))
+    ranks = Dict{NTuple{2, Merge}, Int}()
+    for (token, rank) in encoder
+        len = length(token)
+        isone(len) && continue
+        bpe.max_rank[] = rank
+        merged = Tuple(bpe(StringView(token)))
+        @assert length(merged) == 2
+        if !isnothing(codemap)
+            merged = codemap.(merged)
+        end
+        ranks[parse_merge(Tuple(merged), nothing)] = rank
+    end
+    return BPE(ranks)
+end
+
+
+function bbpe2tiktoken(tkr)
+    _codemap = Ref{Union{Nothing, CodeMap}}(nothing)
+    TextEncodeBase.StructWalk.scan(TextEncodeBase.TokenizerStyle(), tkr) do x
+        x isa CodeMap && (_codemap[] = x)
+    end
+    return bbpe2tiktoken(tkr, _codemap[])
+end
+function bbpe2tiktoken(tkr, codemap::Union{CodeMap, Nothing})
+    found = Ref(false)
+    return replace(tkr) do x
+        x isa CodeNormalizer && !isnothing(codemap) && return x.base
+        x isa BPE && (found[] = true) && return bbpe2tiktoken(x, codemap)
+        return x
+    end
+end
+function bbpe2tiktoken(bpe::BPE, codemap::Union{CodeMap, Nothing} = nothing)
+    @assert all(isnothing, (bpe.endsym, bpe.sepsym)) "Cannot convert bpe with `sepsym` or `endsym`"
+    unmap = isnothing(codemap) ? identity : TextEncodeBase.CodeUnMap(codemap)
+    encoder = Dict(UInt8[b] => i for (i, (_, b)) in enumerate(sort((!isprint(c), c) for c in Char(0):Char(2^8-1))))
+    offset = length(encoder)
+    for (merges, rank) in bpe.merging_rank
+        bytes = vcat(codeunits(unmap(merges[1].string)), codeunits(unmap(merges[2].string)))
+        encoder[bytes] = offset + rank
+    end
+    return TikTokenBPE(encoder)
+end
+
+"""
+    tiktoken2bbpe(tkr, codemap::Union{CodeMap, Nothing} = nothing)
+
+Convert a tiktoken tokenizer (with `bpe::TikToken`) to gpt2-like byte-level tokenizer (with `bpe::BPE`).
+ If `codemap` is provided, it will add the corresponding `CodeNormalizer` to the tokenizer.
+
+see also: [`bbpe2tiktoken`](@ref)
+"""
+tiktoken2bbpe
+
+"""
+    bbpe2tiktoken(tkr)
+
+Convert a gpt2-like byte-level tokenizer (with `bpe::BPE`) to tiktoken tokenizer (with `bpe::TikToken`).
+ If there is a `CodeNormalizer` in the tokenizer, it will be removed accordingly.
+
+see also: [`tiktoken2bbpe`](@ref)
+"""
+bbpe2tiktoken

--- a/src/tiktoken.jl
+++ b/src/tiktoken.jl
@@ -1,0 +1,42 @@
+using Artifacts, LazyArtifacts
+using Base64
+
+_load_tiktoken_encoder_dict(path) = Dict((((token, rank) = split(line); base64decode(token) => parse(Int, rank)) for line in readlines(path)))
+_load_tiktoken_encoder(path) = TikTokenBPE(_load_tiktoken_encoder_dict(path))
+
+function load_tiktoken_bpe(name)
+    artifact_dir = try
+        @artifact_str(name)
+    catch e
+        throw(ArgumentError("No tiktoken model named $name."))
+    end
+    path = joinpath(artifact_dir, "$(name).tiktoken")
+    return _load_tiktoken_encoder(path)
+end
+
+
+struct TikTokenBPE <: AbstractBPE
+    encoder::Dict{Vector{UInt8}, Int}
+end
+(bpe::TikTokenBPE)(x) = bytepairencode(bpe, x)
+
+function Base.getproperty(bpe::TikTokenBPE, sym::Symbol)
+    if sym == :endsym || sym == :sepsym
+        return nothing
+    end
+    return getfield(bpe, sym)
+end
+
+function Base.show(io::IO, bpe::TikTokenBPE)
+    print(io, "TikTokenBPE(")
+    print(io, length(bpe.encoder))
+    print(io, " merges)")
+end
+
+units_itr(bpe::TikTokenBPE, x) = Iterators.map(i->Merge(x, i-1, 1, false, false), 1:ncodeunits(x))
+
+function getrank(bpe::TikTokenBPE, m)
+    m = Merge(m...)
+    r = get(bpe.encoder, @inbounds(@view(codeunits(m.string)[m.offset .+ (1:m.ncodeunits)])), typemax(Int))
+    return r
+end

--- a/src/tokenization.jl
+++ b/src/tokenization.jl
@@ -5,6 +5,9 @@ using TextEncodeBase: BaseTokenization, WordNormalizer, DefaultTokenization, Wra
 struct GPT2Tokenization <: BaseTokenization end
 TextEncodeBase.splitting(::GPT2Tokenization, s::SentenceStage) = gpt2_tokenizer(getvalue(s))
 
+struct Cl100kBaseTokenization <: BaseTokenization end
+TextEncodeBase.splitting(::Cl100kBaseTokenization, s::SentenceStage) = cl100k_base_tokenizer(getvalue(s))
+
 struct BPETokenization{T <: AbstractTokenization, B <: AbstractBPE} <: WrappedTokenization{T}
     base::T
     bpe::B

--- a/test/Artifacts.toml
+++ b/test/Artifacts.toml
@@ -1,0 +1,8 @@
+[xnli_dev]
+git-tree-sha1 = "fb42e6f4a4522b30eb09d21786b90617c4792113"
+lazy = true
+
+    [[xnli_dev.download]]
+    sha256 = "9fa4c2b8ff5194eb3eb9cd63a264a2f1e2b9e24f5d71781d524cfe0f4b268c25"
+    url = "https://gist.github.com/chengchingwen/27796c1d39efdae744e5abec94ecfdb6/raw/fb42e6f4a4522b30eb09d21786b90617c4792113.tar.gz"
+

--- a/test/CondaPkg.toml
+++ b/test/CondaPkg.toml
@@ -1,0 +1,2 @@
+[pip.deps]
+tiktoken = ""

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TextEncodeBase = "f92c20c0-9f2a-4705-8116-881385faba05"
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,10 @@
+using CondaPkg
+testproj_dir = dirname(Base.load_path()[1])
+cp(joinpath(@__DIR__, "CondaPkg.toml"), joinpath(testproj_dir, "CondaPkg.toml"))
+
+using Artifacts, LazyArtifacts
+const artifact_dir = @artifact_str("xnli_dev", nothing, joinpath(@__DIR__, "Artifacts.toml"))
+
 using BytePairEncoding
 using TextEncodeBase
 using Test
@@ -13,6 +20,7 @@ tests = [
     "learn",
     "bpe",
     "bbpe",
+    "tiktoken",
 ]
 
 @testset "BytePairEncoding" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ testproj_dir = dirname(Base.load_path()[1])
 cp(joinpath(@__DIR__, "CondaPkg.toml"), joinpath(testproj_dir, "CondaPkg.toml"))
 
 using Artifacts, LazyArtifacts
-const artifact_dir = @artifact_str("xnli_dev", nothing, joinpath(@__DIR__, "Artifacts.toml"))
+const artifact_dir = @artifact_str("xnli_dev") # artifact_toml = joinpath(@__DIR__, "Artifacts.toml")
 
 using BytePairEncoding
 using TextEncodeBase

--- a/test/test_bbpe.jl
+++ b/test/test_bbpe.jl
@@ -5,8 +5,7 @@ using Downloads
 @testset "ByteLevel" begin
     weird_sentence_answer = ["ðĿ", "ĺ", "Ĳ", "Ġ", "ðĿ", "Ĺ", "Ĩ", "ðĿ", "Ĺ", "Ĥ", "ðĿ", "Ĺ", "´", "ðĿ", "ĺ", "©", "ðĿ", "Ļ", "©", "Ġ", "ðĿ", "ļ", "ķ", "ðĿ", "ļ", "ĺ", "ðĿ", "ļ", "ĺ", "k", "Ġ", "ðĿ", "Ļ", "ĩ", "ðĿ", "ĺ", "ª", "ðĿ", "Ĺ", "¸", "ðĿ", "ĸ", "¾", "Ġ", "ðĿ", "ĸ", "Ĩ", "Ġ", "ðĿ", "ĸ", "ĵ", "ðĿ", "ĸ", "Ķ", "ðĿ", "ĸ", "Ĺ", "ðĿ", "ķ", "ŀ", "ðĿ", "ķ", "Ĵ", "ðĿ", "ķ", "Ŀ", "Ġ", "ðĿ", "Ķ", "°", "ðĿ", "ĵ", "®", "ðĿ", "ĵ", "ĥ", "ðĿ", "Ĵ", "ķ", "ðĿ", "ĳ", "Ĵ", "ðĿ", "Ĳ", "§", "ce"]
 
-    bpe = BPE(Downloads.download("https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-merges.txt"))
-    tkr = FlatTokenizer(CodeNormalizer(BPETokenization(GPT2Tokenization(), bpe), gpt2_codemap()))
+    tkr = BytePairEncoding.load_gpt2()
     @test map(getvalue, tkr(Sentence("𝘐 𝗆𝗂𝗴𝘩𝙩 𝚕𝚘𝚘k 𝙇𝘪𝗸𝖾 𝖆 𝖓𝖔𝖗𝕞𝕒𝕝 𝔰𝓮𝓃𝒕𝑒𝐧ce"))) == weird_sentence_answer
 
     merges = Dict(

--- a/test/test_tiktoken.jl
+++ b/test/test_tiktoken.jl
@@ -1,0 +1,33 @@
+const xnli = readlines(joinpath(artifact_dir, "xnli-dev.txt"))
+using PythonCall
+const tiktoken = pyimport("tiktoken")
+
+using TextEncodeBase: Sentence, getvalue
+
+@testset "TikToken" begin
+    for model in (
+        "cl100k_base",
+        "p50k_base",
+        "p50k_edit",
+        "r50k_base",
+    )
+        tkr = BytePairEncoding.load_tiktoken(model)
+        pytkr = tiktoken.get_encoding(model)
+        for line in xnli
+            tokens = map(getvalue, tkr(Sentence(line)))
+            @test join(tokens) == line
+            @test tokens == map(py->pyconvert(Base.CodeUnits, py).s, pytkr.decode_single_token_bytes.(pytkr.encode(line)))
+        end
+    end
+
+    @testset "gpt2" begin
+        tkr = BytePairEncoding.load_gpt2()
+        unmap = TextEncodeBase.CodeUnMap(tkr.tokenization.base.codemap)
+        pytkr = tiktoken.get_encoding("gpt2")
+        for line in xnli
+            tokens = map(unmap ∘ getvalue, tkr(Sentence(line)))
+            @test join(tokens) == line
+            @test tokens == map(py->pyconvert(Base.CodeUnits, py).s, pytkr.decode_single_token_bytes.(pytkr.encode(line)))
+        end
+    end
+end

--- a/test/test_tiktoken.jl
+++ b/test/test_tiktoken.jl
@@ -17,6 +17,7 @@ using TextEncodeBase: Sentence, getvalue
     )
         tkr = load_tiktoken(model)
         tkr2 = tiktoken2bbpe(tkr, codemap)
+        @test tkr.tokenization.base.bpe.encoder == bbpe2tiktoken(tkr2).tokenization.base.bpe.encoder
         pytkr = tiktoken.get_encoding(model)
         for line in xnli
             tokens = map(getvalue, tkr(Sentence(line)))
@@ -32,6 +33,8 @@ using TextEncodeBase: Sentence, getvalue
         tkr = load_gpt2()
         unmap = TextEncodeBase.CodeUnMap(tkr.tokenization.base.codemap)
         tkr2 = bbpe2tiktoken(tkr)
+        @test tkr.tokenization.base.base.bpe.merging_rank ==
+            tiktoken2bbpe(tkr2, codemap).tokenization.base.base.bpe.merging_rank
         pytkr = tiktoken.get_encoding("gpt2")
         for line in xnli
             tokens = map(unmap ∘ getvalue, tkr(Sentence(line)))

--- a/test/test_tiktoken.jl
+++ b/test/test_tiktoken.jl
@@ -2,32 +2,44 @@ const xnli = readlines(joinpath(artifact_dir, "xnli-dev.txt"))
 using PythonCall
 const tiktoken = pyimport("tiktoken")
 
+using BytePairEncoding: load_tiktoken, load_gpt2, tiktoken2bbpe, bbpe2tiktoken, gpt2_codemap
 using TextEncodeBase: Sentence, getvalue
 
 @testset "TikToken" begin
+    codemap = gpt2_codemap()
+    unmap = TextEncodeBase.CodeUnMap(codemap)
     for model in (
         "cl100k_base",
         "p50k_base",
         "p50k_edit",
         "r50k_base",
+        "gpt2",
     )
-        tkr = BytePairEncoding.load_tiktoken(model)
+        tkr = load_tiktoken(model)
+        tkr2 = tiktoken2bbpe(tkr, codemap)
         pytkr = tiktoken.get_encoding(model)
         for line in xnli
             tokens = map(getvalue, tkr(Sentence(line)))
             @test join(tokens) == line
             @test tokens == map(py->pyconvert(Base.CodeUnits, py).s, pytkr.decode_single_token_bytes.(pytkr.encode(line)))
+            tokens2 = map(unmap ∘ getvalue, tkr2(Sentence(line)))
+            @test join(tokens2) == line
+            @test tokens == tokens2
         end
     end
 
     @testset "gpt2" begin
-        tkr = BytePairEncoding.load_gpt2()
+        tkr = load_gpt2()
         unmap = TextEncodeBase.CodeUnMap(tkr.tokenization.base.codemap)
+        tkr2 = bbpe2tiktoken(tkr)
         pytkr = tiktoken.get_encoding("gpt2")
         for line in xnli
             tokens = map(unmap ∘ getvalue, tkr(Sentence(line)))
             @test join(tokens) == line
             @test tokens == map(py->pyconvert(Base.CodeUnits, py).s, pytkr.decode_single_token_bytes.(pytkr.encode(line)))
+            tokens2 = map(getvalue, tkr2(Sentence(line)))
+            @test join(tokens2) == line
+            @test tokens == tokens2
         end
     end
 end


### PR DESCRIPTION
Support the tokenizers provided by [tiktoken](https://github.com/openai/tiktoken). The tokenizer files are re-host on my gist due to `Artifacts.jl` lacking support for [lazy artifact without unpacking](https://github.com/JuliaLang/Pkg.jl/issues/2764). 

cc @ztangent